### PR TITLE
Improved entrypoint script: accept ip

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
 HOSTNAME=$1
-IP=$(dig +short "$HOSTNAME"| tail -n 1)
-if [ ! -z "$IP"] ; then
-  echo  python3 -u DRipper.py -s "$IP" -t 135 -p 443
+if [ -z "$HOSTNAME" ] ; then
+  echo error: check your hostname.
 else
-  echo python3 -u DRipper.py -s "$HOSTNAME" -t 135 -p 443
+  IP=$(dig +short "$HOSTNAME"| tail -n 1)
+  if [ ! -z "$IP" ] ; then
+    echo  python3 -u DRipper.py -s "$IP" -t 135 -p 443
+  else
+    echo python3 -u DRipper.py -s "$HOSTNAME" -t 135 -p 443
+  fi
 fi

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -6,8 +6,8 @@ if [ -z "$HOSTNAME" ] ; then
 else
   IP=$(dig +short "$HOSTNAME"| tail -n 1)
   if [ ! -z "$IP" ] ; then
-    echo  python3 -u DRipper.py -s "$IP" -t 135 -p 443
+    python3 -u DRipper.py -s "$IP" -t 135 -p 443
   else
-    echo python3 -u DRipper.py -s "$HOSTNAME" -t 135 -p 443
+    python3 -u DRipper.py -s "$HOSTNAME" -t 135 -p 443
   fi
 fi

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -2,4 +2,8 @@
 
 HOSTNAME=$1
 IP=$(dig +short "$HOSTNAME"| tail -n 1)
-python3 -u DRipper.py -s "$IP" -t 135 -p 443
+if [ ! -z "$IP"] ; then
+  echo  python3 -u DRipper.py -s "$IP" -t 135 -p 443
+else
+  echo python3 -u DRipper.py -s "$HOSTNAME" -t 135 -p 443
+fi


### PR DESCRIPTION
There wasno ability to start it with regular ip address ratther than dns name;
The dig command return empty string when ip is being passed through, in that case I guess we check empty dig result and then start either ip or dns script